### PR TITLE
WIP: Volume Config

### DIFF
--- a/yak_ros/CMakeLists.txt
+++ b/yak_ros/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(Eigen3 REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
      roscpp
+     eigen_conversions
      pcl_ros
      tf2
      tf2_ros
@@ -37,6 +38,7 @@ find_package(catkin REQUIRED COMPONENTS
      ${cv_bridge_LIBRARIES}
    CATKIN_DEPENDS
      cv_bridge
+     eigen_conversions
      geometry_msgs
      pcl_ros
      sensor_msgs

--- a/yak_ros/include/yak_ros/utils.h
+++ b/yak_ros/include/yak_ros/utils.h
@@ -27,7 +27,8 @@
 #define YAK_ROS_UTILS_H
 #include <yak/kfusion/kinfu.hpp>
 #include <yak_ros_msgs/UpdateKinFuParamsRequest.h>
-
+#include <eigen_conversions/eigen_msg.h>
+#include <opencv2/core/eigen.hpp>
 namespace yak_ros
 {
 /**
@@ -69,8 +70,11 @@ bool updateParams(kfusion::KinFuParams& params, yak_ros_msgs::UpdateKinFuParamsR
     }
     else if (param == request.VOLUME_POSE)
     {
-      // I think it is a bad idea to let people change this.
-      return false;
+      Eigen::Isometry3d mid;
+      tf::poseMsgToEigen(request.kinfu_params.volume_pose, mid);
+      params.volume_pose= cv::Affine3f::Identity().translate(cv::Vec3f(mid.translation().x(), mid.translation().y(), mid.translation().z()));
+//      cv::eigen2cv(mid.matrix(),why);
+//      params.volume_pose.matrix = why;
     }
     else if (param == request.BILATERAL_SIGMA_DEPTH)
     {

--- a/yak_ros/package.xml
+++ b/yak_ros/package.xml
@@ -14,6 +14,7 @@
 
   <depend>libpcl-all-dev</depend>
   <depend>eigen</depend>
+  <depend>eigen_conversions</depend>
   <depend>yak</depend>
   <depend>yak_ros_msgs</depend>
 

--- a/yak_ros_msgs/CMakeLists.txt
+++ b/yak_ros_msgs/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(yak_ros_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
+  eigen_conversions
   geometry_msgs
   message_generation
   std_msgs

--- a/yak_ros_msgs/package.xml
+++ b/yak_ros_msgs/package.xml
@@ -11,6 +11,7 @@
 
   <depend>roscpp</depend>
 
+  <depend>eigen_conversions</depend>
   <build_depend>geometry_msgs</build_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
 


### PR DESCRIPTION
The PR adds the ability to move the TSDF volume without needing a new tf frame. Goes with https://github.com/ros-industrial/yak/pull/62 in yak